### PR TITLE
Implemented Service Worker functionality to Cache Assets

### DIFF
--- a/client/src-sw.js
+++ b/client/src-sw.js
@@ -28,8 +28,8 @@ registerRoute(({ request }) => request.mode === 'navigate', pageCache);
 
 // TODO: Implement asset caching
 registerRoute(
-  ({ request }) => ['style', 'script', 'worker'].includes(request.destination),
-  new offlineFallback({
+  ({ request }) => ['style', 'script', 'worker', 'image'].includes(request.destination),
+  new CacheFirst({
     cacheName:'asset-cache',
     plugins: [
       new CacheableResponsePlugin({

--- a/client/src-sw.js
+++ b/client/src-sw.js
@@ -27,4 +27,18 @@ warmStrategyCache({
 registerRoute(({ request }) => request.mode === 'navigate', pageCache);
 
 // TODO: Implement asset caching
-registerRoute();
+registerRoute(
+  ({ request }) => ['style', 'script', 'worker'].includes(request.destination),
+  new offlineFallback({
+    cacheName:'asset-cache',
+    plugins: [
+      new CacheableResponsePlugin({
+        statuses: [0, 200],
+      }),
+      new ExpirationPlugin({
+        maxAgeSeconds: 30 * 24 * 60 * 60
+      })
+    ]
+  })
+
+);

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = () => {
       }),
       new InjectManifest({
         swSrc: './src-sw.js',
-        swDest: 'src-ws.js'
+        swDest: 'src-sw.js'
       })
     ],
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -23,8 +23,8 @@ module.exports = () => {
         title: 'Webpack Plugin'
       }),
       new InjectManifest({
-        swSrc: './src/src-sw.js',
-        swDest: 'service-worker.js'
+        swSrc: './src-sw.js',
+        swDest: 'src-ws.js'
       })
     ],
 

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -21,6 +21,10 @@ module.exports = () => {
       new HtmlWebpackPlugin({
         template: './index.html',
         title: 'Webpack Plugin'
+      }),
+      new InjectManifest({
+        swSrc: './src/src-sw.js',
+        swDest: 'service-worker.js'
       })
     ],
 


### PR DESCRIPTION
- In `webpack.config.js`
    - Added the InjectManifestPlugin
- In `src-sw.js`
    - Changed the cache strategy from offlineFallback to CacheFirst
        - This seemed to serve the assets in the browser even when when users lose internet connection